### PR TITLE
Support serving Podcasts on GitHub Project sites

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -50,7 +50,7 @@
       </div>
     </div>
     <div class="footer-copyright">
-      © 2016 <a href="/">{{ site.title }}</a>
+      © 2016 <a href="{{ site.github.url }}">{{ site.title }}</a>
     </div>
   </div>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,7 +18,7 @@
             {{ site.title }} への感想や質問などは、Twitterでハッシュタグ <a href="https://twitter.com/search?q=%23{{ site.hashtag }}" target="_blank">#{{ site.hashtag }}</a> をご利用ください。
           </div>
           <div class="footer-twitter">
-            <a class="twitter-share-button" href="https://twitter.com/intent/tweet?hashtags={{ site.hashtag }}&url={{ site.url }}">
+            <a class="twitter-share-button" href="https://twitter.com/intent/tweet?hashtags={{ site.hashtag }}&url={{ site.github.url }}">
               Tweet
             </a>
           </div>
@@ -37,13 +37,13 @@
               </li>
             {% endif %}
             <li>
-              <a href="http://subscribeonandroid.com/{{ site.url | remove: "https://" | remove: "http://" }}/feed.xml" target="_blank">Androidで購読</a>
+              <a href="http://subscribeonandroid.com/{{ site.github.url | remove: "https://" | remove: "http://" }}/feed.xml" target="_blank">Androidで購読</a>
             </li>
             <li>
-              <a href="https://push.dog/subscribe?url={{ site.url }}/feed.xml" target="_blank">Pushdogで購読</a>
+              <a href="https://push.dog/subscribe?url={{ site.github.url }}/feed.xml" target="_blank">Pushdogで購読</a>
             </li>
             <li>
-              <a href="{{ site.url }}/feed.xml" target="_blank">RSSで購読</a>
+              <a href="{{ site.github.url }}/feed.xml" target="_blank">RSSで購読</a>
             </li>
           </ul>
         </section>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,14 +5,14 @@
   <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
-  <meta name="twitter:image" content="{{ site.url }}/images/logo.jpg" />
+  <meta name="twitter:image" content="{{ site.github.url }}/images/logo.jpg" />
   <meta name="twitter:title" content="{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}" />
   <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
-  <meta property="og:image" content="{{ site.url }}/images/logo.jpg" />
+  <meta property="og:image" content="{{ site.github.url }}/images/logo.jpg" />
   <meta property="og:site_name" content="{{ site.title }}" />
   <meta property="og:type" content="blog" />
-  <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
-  <link rel="alternate" type="application/rss+xml" href="{{ site.url }}/feed.xml" />
-  <link rel="stylesheet" href="/css/main.css">
+  <meta property="og:url" content="{{ site.github.url }}{{ page.url }}" />
+  <link rel="alternate" type="application/rss+xml" href="{{ site.github.url }}/feed.xml" />
+  <link rel="stylesheet" href="{{ site.github.url }}/css/main.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mediaelement/2.23.4/mediaelementplayer.min.css">
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
   <div class="header-overlay">
     <div class="container">
       <h1 class="header-heading">
-        <a href="/">
+        <a href="{{ site.github.url }}">
           {{ site.title }}
         </a>
       </h1>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -55,7 +55,7 @@
             {{ content }}
           </section>
           <footer class="article-footer">
-            <a class="twitter-share-button" href="https://twitter.com/intent/tweet?hashtags={{ site.hashtag }}&url={{ site.url }}{{ page.url }}&text={{ page.title }}">
+            <a class="twitter-share-button" href="https://twitter.com/intent/tweet?hashtags={{ site.hashtag }}&url={{ site.github.url }}{{ page.url }}&text={{ page.title }}">
               Tweet
             </a>
           </footer>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -8,7 +8,7 @@
         <article class="article card">
           <header class="article-header card-header">
             <h1 class="card-heading">
-              <a href="{{ page.url }}">
+              <a href="{{ page.url | prepend:site.github.url }}">
                 {{ page.title }}
               </a>
             </h1>
@@ -23,14 +23,14 @@
                 controls=""
                 data-mejsoptions='{"alwaysShowControls": true, "alwaysShowHours": true, "enableAutosize": true, "features": ["playpause", "progress", "current", "duration", "volume", "speed"]}'
                 preload="auto"
-                src="{{ page.audio_file_path }}"
+                src="{{ page.audio_file_path | prepend:site.github.url }}"
                 width="100%"
               >
               </audio>
             </p>
             <p class="text-right">
               <small>
-                <a href="{{ page.audio_file_path }}">MP3ファイルをダウンロード</a>
+                <a href="{{ page.audio_file_path | prepend:site.github.url }}">MP3ファイルをダウンロード</a>
               </small>
             </p>
             <h2>
@@ -46,7 +46,7 @@
               {% for actor_id in page.actor_ids %}
                 {% assign actor = site.actors[actor_id] %}
                 <a href="{{ actor.url }}" class="actor" target="_blank">
-                  <img src="{{ actor.image_url }}" alt="{{ actor.name }}" class="actor-image" width="72" height="72">
+                  <img src="{{ actor.image_url | prepend:site.github.url }}" alt="{{ actor.name }}" class="actor-image" width="72" height="72">
                   <br>
                   {{ actor.name }}
                 </a>

--- a/css/blocks/_header.scss
+++ b/css/blocks/_header.scss
@@ -1,5 +1,5 @@
 .header {
-  background-image: url(/images/artwork.jpg);
+  background-image: url(../images/artwork.jpg);
   background-size: cover;
   background-position: center;
 

--- a/feed.xml
+++ b/feed.xml
@@ -3,8 +3,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:media="http://search.yahoo.com/mrss/" xml:lang="{{ site.language }}">
   <channel>
-    <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />
-    <link>{{ site.url }}</link>
+    <atom:link href="{{ site.github.url }}/feed.xml" rel="self" type="application/rss+xml" />
+    <link>{{ site.github.url }}</link>
     <title>{{ site.title }}</title>
     <description>{{ site.description | xml_escape }}</description>
     <media:keywords>{{ site.keywords }}</media:keywords>
@@ -18,22 +18,22 @@
       <itunes:name>{{ site.author }}</itunes:name>
       <itunes:email>{{ site.email }}</itunes:email>
     </itunes:owner>
-    <itunes:image href="{{ site.url }}/images/artwork.jpg" />
+    <itunes:image href="{{ site.github.url }}/images/artwork.jpg" />
     <itunes:category text="Technology"/>
     <itunes:explicit>no</itunes:explicit>
     {% for post in site.posts %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <link>{{ site.url }}{{ post.url }}</link>
+        <link>{{ site.github.url }}{{ post.url }}</link>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <description>{{ post.content | xml_escape }}</description>
-        <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
-        <enclosure url="{{ site.url }}{{ post.audio_file_path }}" length="{{ post.audio_file_size }}" type="audio/mp3"/>
+        <guid isPermaLink="true">{{ site.github.url }}{{ post.url }}</guid>
+        <enclosure url="{{ site.github.url }}{{ post.audio_file_path }}" length="{{ post.audio_file_size }}" type="audio/mp3"/>
         <itunes:author>{{ site.author }}</itunes:author>
         <itunes:subtitle>{{ post.description }}</itunes:subtitle>
         <itunes:duration>{{ post.duration }}</itunes:duration>
         <itunes:explicit>no</itunes:explicit>
-        <media:thumbnail url="{{ site.url }}/images/artwork.jpg"/>
+        <media:thumbnail url="{{ site.github.url }}/images/artwork.jpg"/>
       </item>
     {% endfor %}
   </channel>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ layout: default
     {% for post in site.posts %}
       <article class="list-group-element">
         <h1 class="list-group-element-heading">
-          <a href="{{ post.url }}">{{ post.title | escape }}</a>
+          <a href="{{ post.url | prepend:site.github.url }}">{{ post.title | escape }}</a>
         </h1>
         <footer class="list-group-element-footer">
           {{ post.date | date: "%Y年%m月%d日" }}
@@ -18,7 +18,7 @@ layout: default
         <div class="list-group-element-images">
           {% for actor_id in post.actor_ids %}
             {% assign actor = site.actors[actor_id] %}
-            <img src="{{ actor.image_url }}" alt="{{ actor.name }}" class="list-group-element-images-element" width="40" height="40">
+            <img src="{{ actor.image_url | prepend:site.github.url }}" alt="{{ actor.name }}" class="list-group-element-images-element" width="40" height="40">
           {% endfor %}
         </div>
       </article>


### PR DESCRIPTION
# Why
Currently yattecast cannot serve Podcasts on Project sites.
It uses `site.url` and root-relative URLs, like `<img src="/images/foo.png"/>`

Jekyll has special property `site.github.url` to support serving files on Project sites.
With this property, yattecast can support serving Podcasts on Project sites.
https://jekyllrb.com/docs/github-pages/

# Changes
This PR has 4 changes:

- Use relative paths in CSS, not root-relative URLs
- Prepend or append `site.github.url` to root-relative URLs
- Replaced `site.url` with `site.github.url`
- Replaced `/` with `site.github.url`

# Example
- User site: http://fand.github.io/
- Project site: http://fand.github.io/yattecast/

The links and the resource URLs working right.
